### PR TITLE
chore: Rebrand repository from annex to claudex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Annex - Claude Code Skills
+# Claudex - Claude Code Skills
 
 > A curated collection of experimental skills for [Claude Code](https://claude.com/claude-code)
 
@@ -26,10 +26,10 @@ Install skills globally to use them across all your projects:
 
 ```bash
 # Clone this repository
-git clone https://github.com/cskiro/annex.git
+git clone https://github.com/cskiro/claudex.git
 
 # Install a skill globally
-cp -r annex/codebase-auditor ~/.claude/skills/
+cp -r claudex/codebase-auditor ~/.claude/skills/
 
 # Use in any project
 cd /path/to/your-project
@@ -43,7 +43,7 @@ Install skills for a specific project only:
 ```bash
 # In your project directory
 mkdir -p .claude/skills
-cp -r /path/to/annex/codebase-auditor .claude/skills/
+cp -r /path/to/claudex/codebase-auditor .claude/skills/
 
 # Skill now available only in this project
 ```
@@ -110,7 +110,7 @@ Automatically processes Claude Code conversation history, enables RAG-powered se
 ## Repository Structure
 
 ```
-annex/
+claudex/
 ├── codebase-auditor/              # General codebase auditor
 │   ├── SKILL.md                   # Skill definition
 │   ├── README.md                  # Documentation

--- a/cc-insights/README.md
+++ b/cc-insights/README.md
@@ -20,12 +20,12 @@ This skill transforms your Claude Code conversations into actionable insights wi
 ✅ **Globally Installed and Operational** (October 26, 2025)
 
 - **Location**: `~/.claude/skills/cc-insights/`
-- **Database**: 19 conversations indexed (5 annex + 14 heisenberg)
+- **Database**: 19 conversations indexed (5 claudex + 14 heisenberg)
 - **Messages**: 5,003 total (1,667 user, 2,341 assistant)
 - **RAG Index**: 19 conversations embedded with all-MiniLM-L6-v2 (384-dim)
 - **Status**: Fully functional and ready for use across all projects
 
-**Cross-Project Support**: This skill uses a global database, enabling insights across multiple projects (annex, heisenberg, etc.).
+**Cross-Project Support**: This skill uses a global database, enabling insights across multiple projects (claudex, heisenberg, etc.).
 
 ## Quick Start
 
@@ -48,7 +48,7 @@ Process your existing conversations:
 
 ```bash
 # Process all conversations for current project
-python scripts/conversation-processor.py --project-name annex --verbose --stats
+python scripts/conversation-processor.py --project-name claudex --verbose --stats
 
 # Build semantic search index
 python scripts/rag_indexer.py --verbose --stats
@@ -146,7 +146,7 @@ Parse JSONL files and extract conversation metadata.
 python scripts/conversation-processor.py [OPTIONS]
 
 Options:
-  --project-name TEXT    Project to process (default: annex)
+  --project-name TEXT    Project to process (default: claudex)
   --db-path PATH         Database path
   --reindex              Reprocess all (ignore cache)
   --verbose              Show detailed logs
@@ -327,7 +327,7 @@ ls rag_indexer.py
 **Solution:**
 ```bash
 # Run processor first
-python scripts/conversation-processor.py --project-name annex --verbose
+python scripts/conversation-processor.py --project-name claudex --verbose
 ```
 
 ### "No conversations found"
@@ -397,7 +397,7 @@ The system automatically handles incremental updates:
 **Recommended workflow:**
 ```bash
 # Daily/weekly: Run both for new conversations
-python scripts/conversation-processor.py --project-name annex
+python scripts/conversation-processor.py --project-name claudex
 python scripts/rag_indexer.py
 
 # Takes <5s if only a few new conversations
@@ -519,5 +519,5 @@ For issues or questions:
 
 ---
 
-**Built for Connor's annex project**
+**Built for Connor's claudex project**
 *Zero-effort conversation intelligence*

--- a/claude-md-auditor/CHANGELOG.md
+++ b/claude-md-auditor/CHANGELOG.md
@@ -217,5 +217,5 @@ Apache 2.0 - Example skill for demonstration
 ---
 
 **Maintained By**: Connor (based on Anthropic Skills framework)
-**Repository**: https://github.com/cskiro/annex/tree/main/claude-md-auditor
+**Repository**: https://github.com/cskiro/claudex/tree/main/claude-md-auditor
 **Documentation**: See README.md and reference/ directory

--- a/claude-md-auditor/README.md
+++ b/claude-md-auditor/README.md
@@ -130,8 +130,8 @@ ls ~/.claude/skills/claude-md-auditor/SKILL.md
 
 ```bash
 # Clone repository
-git clone https://github.com/cskiro/annex.git
-cd annex/claude-md-auditor
+git clone https://github.com/cskiro/claudex.git
+cd claudex/claude-md-auditor
 
 # Run directly (Python 3.8+ required, no dependencies)
 python scripts/analyzer.py path/to/CLAUDE.md

--- a/claude-md-auditor/SUCCESS_CRITERIA_VALIDATION.md
+++ b/claude-md-auditor/SUCCESS_CRITERIA_VALIDATION.md
@@ -185,7 +185,7 @@ Connor's CLAUDE.md demonstrates excellent clarity:
 - ✅ **Specific standards**: "TypeScript strict mode", "80% test coverage"
 - ✅ **Measurable criteria**: Numeric thresholds, explicit rules
 - ✅ **No vague advice**: All instructions actionable
-- ✅ **Project-specific**: Focused on annex project requirements
+- ✅ **Project-specific**: Focused on claudex project requirements
 
 **Refactored Template Clarity**:
 ```markdown


### PR DESCRIPTION
## Summary

Update all user-facing documentation to reflect repository rename from "annex" to "claudex".

## Changes

### Documentation Updates (5 files)
- **README.md**: Repository title, clone URLs, installation paths
- **cc-insights/README.md**: Project name references, database stats, code examples
- **claude-md-auditor/README.md**: Clone URLs, installation instructions
- **claude-md-auditor/CHANGELOG.md**: Repository URL
- **claude-md-auditor/SUCCESS_CRITERIA_VALIDATION.md**: Project-specific references

### Impact
- ✅ **Documentation-only changes** - No functional code modifications
- ✅ **Zero breaking changes** - GitHub redirects ensure existing clones work
- ✅ **Consistent branding** - All references now use "claudex"

## Testing
- [x] Local git remote updated and tested
- [x] Backup branch created (`pre-rename-backup`)
- [x] All documentation references verified

## Checklist
- [x] All user-facing "annex" references updated to "claudex"
- [x] Clone URLs point to new repository name
- [x] Installation instructions reflect new paths
- [x] No functional code changes
- [x] Backup branch exists for safety

🤖 Generated with [Claude Code](https://claude.com/claude-code)