### PR TITLE
feat: Add Claude Code marketplace infrastructure

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,91 @@
+{
+  "name": "claudex",
+  "metadata": {
+    "description": "Curated collection of production-ready skills for Claude Code - auditing, validation, and conversation analysis",
+    "version": "2.0.0-beta",
+    "homepage": "https://github.com/cskiro/claudex",
+    "pluginRoot": "./"
+  },
+  "owner": {
+    "name": "Connor",
+    "url": "https://github.com/cskiro"
+  },
+  "plugins": [
+    {
+      "name": "codebase-auditor",
+      "source": "./codebase-auditor",
+      "description": "Comprehensive static analysis tool that audits codebases for quality, security, and technical debt based on 2024-25 SDLC best practices",
+      "version": "1.0.0-beta",
+      "author": "Connor",
+      "license": "Apache-2.0",
+      "keywords": [
+        "audit",
+        "code-quality",
+        "security",
+        "testing",
+        "technical-debt",
+        "owasp",
+        "wcag",
+        "dora"
+      ],
+      "category": "analysis",
+      "homepage": "https://github.com/cskiro/claudex/tree/main/codebase-auditor"
+    },
+    {
+      "name": "bulletproof-react-auditor",
+      "source": "./bulletproof-react-auditor",
+      "description": "React application auditor based on Bulletproof React architecture guide - evaluates React projects against production-ready standards",
+      "version": "1.0.0-beta",
+      "author": "Connor",
+      "license": "Apache-2.0",
+      "keywords": [
+        "react",
+        "typescript",
+        "architecture",
+        "best-practices",
+        "bulletproof-react",
+        "component-patterns",
+        "state-management"
+      ],
+      "category": "analysis",
+      "homepage": "https://github.com/cskiro/claudex/tree/main/bulletproof-react-auditor"
+    },
+    {
+      "name": "claude-md-auditor",
+      "source": "./claude-md-auditor",
+      "description": "Validates and audits CLAUDE.md configuration files for Claude Code - ensures compliance with schema standards and best practices for LLM configuration",
+      "version": "1.0.0-beta",
+      "author": "Connor",
+      "license": "Apache-2.0",
+      "keywords": [
+        "configuration",
+        "validation",
+        "claude-md",
+        "schema",
+        "best-practices",
+        "llm-config"
+      ],
+      "category": "tooling",
+      "homepage": "https://github.com/cskiro/claudex/tree/main/claude-md-auditor"
+    },
+    {
+      "name": "cc-insights",
+      "source": "./cc-insights",
+      "description": "RAG-powered conversation analysis and semantic search - automatically processes Claude Code conversation history and generates intelligent insight reports",
+      "version": "2.0.0-beta",
+      "author": "Connor",
+      "license": "Apache-2.0",
+      "keywords": [
+        "rag",
+        "semantic-search",
+        "analytics",
+        "insights",
+        "conversation-analysis",
+        "pattern-detection",
+        "chromadb"
+      ],
+      "category": "productivity",
+      "homepage": "https://github.com/cskiro/claudex/tree/main/cc-insights"
+    }
+  ]
+}

--- a/.claude-plugin/validate-marketplace.py
+++ b/.claude-plugin/validate-marketplace.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""
+Marketplace Validation Script for claudex
+
+Validates the marketplace.json file and plugin integrity for Claude Code plugin marketplace.
+Ensures all required fields are present, plugins are correctly structured, and references are valid.
+
+Usage:
+    python3 .claude-plugin/validate-marketplace.py
+
+Exit Codes:
+    0 - All validations passed
+    1 - Validation errors found
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+# ANSI color codes for terminal output
+class Colors:
+    GREEN = '\033[92m'
+    RED = '\033[91m'
+    YELLOW = '\033[93m'
+    BLUE = '\033[94m'
+    RESET = '\033[0m'
+    BOLD = '\033[1m'
+
+class MarketplaceValidator:
+    def __init__(self, repo_root: Path):
+        self.repo_root = repo_root
+        self.marketplace_path = repo_root / ".claude-plugin" / "marketplace.json"
+        self.errors: List[str] = []
+        self.warnings: List[str] = []
+        self.info: List[str] = []
+
+    def validate(self) -> bool:
+        """Run all validations and return True if successful."""
+        print(f"{Colors.BOLD}🔍 Validating claudex marketplace...{Colors.RESET}\n")
+
+        # Check marketplace.json exists
+        if not self.marketplace_path.exists():
+            self.errors.append(f"marketplace.json not found at {self.marketplace_path}")
+            return False
+
+        # Load and parse marketplace.json
+        try:
+            with open(self.marketplace_path, 'r') as f:
+                self.marketplace = json.load(f)
+        except json.JSONDecodeError as e:
+            self.errors.append(f"Invalid JSON in marketplace.json: {e}")
+            return False
+
+        # Run validation checks
+        self._validate_marketplace_structure()
+        self._validate_marketplace_metadata()
+        self._validate_plugins()
+        self._validate_plugin_files()
+        self._validate_skill_files()
+
+        # Print results
+        self._print_results()
+
+        return len(self.errors) == 0
+
+    def _validate_marketplace_structure(self):
+        """Validate required top-level fields."""
+        required_fields = ['name', 'owner', 'plugins']
+
+        for field in required_fields:
+            if field not in self.marketplace:
+                self.errors.append(f"Missing required field: '{field}'")
+
+        # Validate owner structure
+        if 'owner' in self.marketplace:
+            if not isinstance(self.marketplace['owner'], dict):
+                self.errors.append("'owner' must be an object")
+            elif 'name' not in self.marketplace['owner']:
+                self.errors.append("'owner.name' is required")
+
+    def _validate_marketplace_metadata(self):
+        """Validate metadata fields."""
+        if 'metadata' in self.marketplace:
+            metadata = self.marketplace['metadata']
+
+            if 'description' not in metadata:
+                self.warnings.append("metadata.description is recommended")
+
+            if 'version' not in metadata:
+                self.warnings.append("metadata.version is recommended")
+            else:
+                # Validate semantic versioning format
+                version = metadata['version']
+                if not self._is_valid_semver(version):
+                    self.warnings.append(f"Version '{version}' doesn't follow semantic versioning (e.g., 1.0.0-beta)")
+
+    def _validate_plugins(self):
+        """Validate plugin entries."""
+        if 'plugins' not in self.marketplace:
+            return
+
+        plugins = self.marketplace['plugins']
+
+        if not isinstance(plugins, list):
+            self.errors.append("'plugins' must be an array")
+            return
+
+        if len(plugins) == 0:
+            self.warnings.append("No plugins defined in marketplace")
+
+        plugin_names = set()
+
+        for idx, plugin in enumerate(plugins):
+            self._validate_plugin_entry(plugin, idx, plugin_names)
+
+    def _validate_plugin_entry(self, plugin: Dict, idx: int, plugin_names: set):
+        """Validate a single plugin entry."""
+        # Check required fields
+        if 'name' not in plugin:
+            self.errors.append(f"Plugin #{idx}: Missing required field 'name'")
+            return
+
+        name = plugin['name']
+
+        # Check for duplicate names
+        if name in plugin_names:
+            self.errors.append(f"Plugin '{name}': Duplicate plugin name")
+        plugin_names.add(name)
+
+        # Check source field
+        if 'source' not in plugin:
+            self.errors.append(f"Plugin '{name}': Missing required field 'source'")
+        else:
+            source = plugin['source']
+            if not isinstance(source, str):
+                self.errors.append(f"Plugin '{name}': 'source' must be a string")
+            elif not source.startswith('./'):
+                self.warnings.append(f"Plugin '{name}': Source should be relative path starting with './'")
+
+        # Check recommended fields
+        recommended = ['description', 'version', 'author', 'license']
+        for field in recommended:
+            if field not in plugin:
+                self.warnings.append(f"Plugin '{name}': Missing recommended field '{field}'")
+
+        # Validate version format
+        if 'version' in plugin and not self._is_valid_semver(plugin['version']):
+            self.warnings.append(f"Plugin '{name}': Version '{plugin['version']}' doesn't follow semantic versioning")
+
+        # Validate keywords (if present)
+        if 'keywords' in plugin:
+            if not isinstance(plugin['keywords'], list):
+                self.errors.append(f"Plugin '{name}': 'keywords' must be an array")
+            elif len(plugin['keywords']) == 0:
+                self.warnings.append(f"Plugin '{name}': Empty keywords array")
+
+    def _validate_plugin_files(self):
+        """Validate that plugin directories and plugin.json files exist."""
+        if 'plugins' not in self.marketplace:
+            return
+
+        for plugin in self.marketplace['plugins']:
+            if 'name' not in plugin or 'source' not in plugin:
+                continue
+
+            name = plugin['name']
+            source = plugin['source']
+
+            # Resolve plugin directory path
+            if source.startswith('./'):
+                plugin_dir = self.repo_root / source.lstrip('./')
+            else:
+                plugin_dir = self.repo_root / source
+
+            # Check directory exists
+            if not plugin_dir.exists():
+                self.errors.append(f"Plugin '{name}': Directory not found: {plugin_dir}")
+                continue
+
+            if not plugin_dir.is_dir():
+                self.errors.append(f"Plugin '{name}': Source path is not a directory: {plugin_dir}")
+                continue
+
+            # Check plugin.json exists
+            plugin_json_path = plugin_dir / "plugin.json"
+            if not plugin_json_path.exists():
+                self.errors.append(f"Plugin '{name}': Missing plugin.json at {plugin_json_path}")
+                continue
+
+            # Validate plugin.json
+            try:
+                with open(plugin_json_path, 'r') as f:
+                    plugin_manifest = json.load(f)
+
+                # Check name matches
+                if 'name' in plugin_manifest and plugin_manifest['name'] != name:
+                    self.warnings.append(
+                        f"Plugin '{name}': Name mismatch between marketplace.json and plugin.json "
+                        f"(marketplace: '{name}', manifest: '{plugin_manifest['name']}')"
+                    )
+
+                # Validate components structure
+                if 'components' not in plugin_manifest:
+                    self.warnings.append(f"Plugin '{name}': Missing 'components' field in plugin.json")
+                elif 'agents' not in plugin_manifest['components']:
+                    self.warnings.append(f"Plugin '{name}': Missing 'components.agents' field")
+
+            except json.JSONDecodeError as e:
+                self.errors.append(f"Plugin '{name}': Invalid JSON in plugin.json: {e}")
+
+    def _validate_skill_files(self):
+        """Validate that SKILL.md files exist and are referenced correctly."""
+        if 'plugins' not in self.marketplace:
+            return
+
+        for plugin in self.marketplace['plugins']:
+            if 'name' not in plugin or 'source' not in plugin:
+                continue
+
+            name = plugin['name']
+            source = plugin['source']
+
+            # Resolve plugin directory path
+            if source.startswith('./'):
+                plugin_dir = self.repo_root / source.lstrip('./')
+            else:
+                plugin_dir = self.repo_root / source
+
+            if not plugin_dir.exists():
+                continue
+
+            # Check SKILL.md exists
+            skill_md_path = plugin_dir / "SKILL.md"
+            if not skill_md_path.exists():
+                self.errors.append(f"Plugin '{name}': Missing SKILL.md at {skill_md_path}")
+                continue
+
+            # Validate SKILL.md has content
+            try:
+                with open(skill_md_path, 'r') as f:
+                    content = f.read()
+                    if len(content.strip()) == 0:
+                        self.errors.append(f"Plugin '{name}': SKILL.md is empty")
+                    elif len(content) < 100:
+                        self.warnings.append(f"Plugin '{name}': SKILL.md seems very short ({len(content)} chars)")
+            except Exception as e:
+                self.errors.append(f"Plugin '{name}': Could not read SKILL.md: {e}")
+
+    def _is_valid_semver(self, version: str) -> bool:
+        """Check if version follows semantic versioning format."""
+        import re
+        # Basic semver pattern: X.Y.Z[-prerelease][+build]
+        pattern = r'^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'
+        return bool(re.match(pattern, version))
+
+    def _print_results(self):
+        """Print validation results with color coding."""
+        print()
+
+        if self.errors:
+            print(f"{Colors.RED}{Colors.BOLD}❌ Errors ({len(self.errors)}):{Colors.RESET}")
+            for error in self.errors:
+                print(f"  {Colors.RED}• {error}{Colors.RESET}")
+            print()
+
+        if self.warnings:
+            print(f"{Colors.YELLOW}{Colors.BOLD}⚠️  Warnings ({len(self.warnings)}):{Colors.RESET}")
+            for warning in self.warnings:
+                print(f"  {Colors.YELLOW}• {warning}{Colors.RESET}")
+            print()
+
+        if self.info:
+            print(f"{Colors.BLUE}{Colors.BOLD}ℹ️  Info ({len(self.info)}):{Colors.RESET}")
+            for info_msg in self.info:
+                print(f"  {Colors.BLUE}• {info_msg}{Colors.RESET}")
+            print()
+
+        # Final summary
+        if len(self.errors) == 0:
+            plugin_count = len(self.marketplace.get('plugins', []))
+            print(f"{Colors.GREEN}{Colors.BOLD}✅ Validation passed!{Colors.RESET}")
+            print(f"   Marketplace: {self.marketplace.get('name', 'unknown')}")
+            print(f"   Plugins: {plugin_count}")
+            print(f"   Warnings: {len(self.warnings)}")
+            print()
+        else:
+            print(f"{Colors.RED}{Colors.BOLD}❌ Validation failed with {len(self.errors)} error(s){Colors.RESET}")
+            print()
+
+def main():
+    """Main entry point."""
+    # Determine repository root (parent of .claude-plugin directory)
+    script_path = Path(__file__).resolve()
+    repo_root = script_path.parent.parent
+
+    validator = MarketplaceValidator(repo_root)
+    success = validator.validate()
+
+    sys.exit(0 if success else 1)
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -1,0 +1,138 @@
+name: Validate Marketplace
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    name: Validate Marketplace Structure
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+
+      - name: Validate marketplace.json schema
+        run: |
+          echo "📋 Validating marketplace.json schema..."
+          python3 .claude-plugin/validate-marketplace.py
+
+      - name: Check plugin manifests exist
+        run: |
+          echo "📦 Checking plugin manifests..."
+          for plugin in codebase-auditor bulletproof-react-auditor claude-md-auditor cc-insights; do
+            if [ ! -f "$plugin/plugin.json" ]; then
+              echo "❌ Missing plugin.json in $plugin"
+              exit 1
+            else
+              echo "✅ Found plugin.json in $plugin"
+            fi
+          done
+
+      - name: Validate plugin.json files
+        run: |
+          echo "🔍 Validating plugin.json files..."
+          for plugin in codebase-auditor bulletproof-react-auditor claude-md-auditor cc-insights; do
+            if ! python3 -m json.tool "$plugin/plugin.json" > /dev/null; then
+              echo "❌ Invalid JSON in $plugin/plugin.json"
+              exit 1
+            else
+              echo "✅ Valid JSON in $plugin/plugin.json"
+            fi
+          done
+
+      - name: Validate SKILL.md files exist
+        run: |
+          echo "📝 Checking SKILL.md files..."
+          for plugin in codebase-auditor bulletproof-react-auditor claude-md-auditor cc-insights; do
+            if [ ! -f "$plugin/SKILL.md" ]; then
+              echo "❌ Missing SKILL.md in $plugin"
+              exit 1
+            else
+              echo "✅ Found SKILL.md in $plugin"
+            fi
+          done
+
+      - name: Check README files
+        run: |
+          echo "📚 Checking README files..."
+          for plugin in codebase-auditor bulletproof-react-auditor claude-md-auditor cc-insights; do
+            if [ ! -f "$plugin/README.md" ]; then
+              echo "⚠️  Missing README.md in $plugin"
+            else
+              echo "✅ Found README.md in $plugin"
+            fi
+          done
+
+      - name: Check CHANGELOG files
+        run: |
+          echo "📋 Checking CHANGELOG files..."
+          for plugin in codebase-auditor bulletproof-react-auditor claude-md-auditor cc-insights; do
+            if [ ! -f "$plugin/CHANGELOG.md" ]; then
+              echo "⚠️  Missing CHANGELOG.md in $plugin"
+            else
+              echo "✅ Found CHANGELOG.md in $plugin"
+            fi
+          done
+
+      - name: Validate marketplace.json syntax
+        run: |
+          echo "🔧 Validating marketplace.json JSON syntax..."
+          if ! python3 -m json.tool .claude-plugin/marketplace.json > /dev/null; then
+            echo "❌ Invalid JSON in marketplace.json"
+            exit 1
+          else
+            echo "✅ Valid JSON in marketplace.json"
+          fi
+
+      - name: Check for required marketplace fields
+        run: |
+          echo "📋 Checking required marketplace fields..."
+          python3 -c "
+import json
+import sys
+
+with open('.claude-plugin/marketplace.json', 'r') as f:
+    data = json.load(f)
+
+required_fields = ['name', 'owner', 'plugins']
+missing = [f for f in required_fields if f not in data]
+
+if missing:
+    print(f'❌ Missing required fields: {missing}')
+    sys.exit(1)
+
+if not isinstance(data.get('plugins', []), list):
+    print('❌ plugins must be an array')
+    sys.exit(1)
+
+if len(data.get('plugins', [])) == 0:
+    print('⚠️  No plugins defined')
+
+print(f\"✅ Marketplace validation passed ({len(data.get('plugins', []))} plugins)\")
+"
+
+      - name: Summary
+        if: success()
+        run: |
+          echo ""
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "✅ All marketplace validations passed!"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo ""
+          echo "Marketplace: claudex"
+          echo "Plugins validated: 4"
+          echo "  • codebase-auditor"
+          echo "  • bulletproof-react-auditor"
+          echo "  • claude-md-auditor"
+          echo "  • cc-insights"
+          echo ""

--- a/README.md
+++ b/README.md
@@ -20,9 +20,58 @@ This repository contains skills that extend Claude Code's capabilities for commo
 
 ## Quick Start
 
-### Global Installation (Recommended)
+### Install via Marketplace (Recommended)
 
-Install skills globally to use them across all your projects:
+Add the claudex marketplace to your Claude Code:
+
+```bash
+/plugin marketplace add cskiro/claudex
+```
+
+Then browse and install skills:
+
+```bash
+# Browse all available skills
+/plugin
+
+# Or install specific skills directly
+/plugin install codebase-auditor@claudex
+/plugin install bulletproof-react-auditor@claudex
+/plugin install claude-md-auditor@claudex
+/plugin install cc-insights@claudex
+```
+
+### Team Configuration (Auto-Install)
+
+Add to your project's `.claude/settings.json` for automatic setup:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "claudex": {
+      "source": {
+        "source": "github",
+        "repo": "cskiro/claudex"
+      }
+    }
+  },
+  "enabledPlugins": [
+    "codebase-auditor@claudex",
+    "bulletproof-react-auditor@claudex",
+    "claude-md-auditor@claudex",
+    "cc-insights@claudex"
+  ]
+}
+```
+
+When team members trust your repository, these plugins install automatically.
+
+### Manual Installation (Legacy)
+
+<details>
+<summary>Click to expand legacy installation instructions</summary>
+
+#### Global Installation
 
 ```bash
 # Clone this repository
@@ -36,9 +85,7 @@ cd /path/to/your-project
 # In Claude Code, just ask: "Audit this codebase"
 ```
 
-### Project-Local Installation
-
-Install skills for a specific project only:
+#### Project-Local Installation
 
 ```bash
 # In your project directory
@@ -47,6 +94,10 @@ cp -r /path/to/claudex/codebase-auditor .claude/skills/
 
 # Skill now available only in this project
 ```
+
+**Note**: Manual installation is deprecated in favor of marketplace installation. See [Migration Guide](./docs/MIGRATION_GUIDE.md) for upgrade instructions.
+
+</details>
 
 ## Available Skills
 
@@ -179,15 +230,17 @@ Have a useful skill to share? Contributions welcome!
 ## Best Practices
 
 ✅ **Do:**
-- Install frequently-used skills globally (`~/.claude/skills/`)
-- Keep skill-specific docs in the skill directory
-- Use descriptive natural language when invoking skills
+- Install skills via marketplace for automatic updates: `/plugin install skill-name@claudex`
+- Use team configuration (`.claude/settings.json`) to standardize plugins across projects
+- Pin specific versions for production stability (when available)
 - Review generated reports before taking action
+- Use descriptive natural language when invoking skills
 
 ⚠️ **Don't:**
+- Manually copy skills anymore (use marketplace installation)
 - Commit `.claude/skills/` in projects (already in `.gitignore`)
 - Store sensitive data in skill directories
-- Modify global skills for project-specific needs (use local copy instead)
+- Skip version pinning in production environments
 
 ## Documentation
 
@@ -198,7 +251,8 @@ Have a useful skill to share? Contributions welcome!
 - [cc-insights](./cc-insights/README.md) - Conversation analysis & semantic search
 
 ### General Documentation
-- [Skill Installation Guide](./docs/SKILL_INSTALLATION_GUIDE.md) - Complete setup instructions
+- [Migration Guide](./docs/MIGRATION_GUIDE.md) - Upgrade from manual to marketplace installation
+- [Skill Installation Guide](./docs/SKILL_INSTALLATION_GUIDE.md) - Complete setup instructions (legacy)
 - [Handoff Summaries](./docs/) - Development session summaries
 
 ## Requirements

--- a/bulletproof-react-auditor/plugin.json
+++ b/bulletproof-react-auditor/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "bulletproof-react-auditor",
+  "version": "1.0.0-beta",
+  "description": "React application auditor based on the comprehensive Bulletproof React architecture guide - evaluates React projects against production-ready standards",
+  "author": "Connor",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/cskiro/claudex/tree/main/bulletproof-react-auditor",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cskiro/claudex"
+  },
+  "keywords": [
+    "react",
+    "typescript",
+    "architecture",
+    "best-practices",
+    "bulletproof-react",
+    "component-patterns",
+    "state-management"
+  ],
+  "requirements": {
+    "python": ">=3.8"
+  },
+  "components": {
+    "agents": [
+      {
+        "name": "bulletproof-react-auditor",
+        "manifestPath": "SKILL.md"
+      }
+    ]
+  },
+  "metadata": {
+    "category": "analysis",
+    "status": "beta",
+    "tested": "1-2 projects locally"
+  }
+}

--- a/cc-insights/CHANGELOG.md
+++ b/cc-insights/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog - cc-insights
+
+All notable changes to the cc-insights skill will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0-beta] - 2025-10-26
+
+### Added
+- Initial beta release of RAG-powered conversation analysis system
+- **Automatic Processing**: Scans `~/.claude/conversations/` and indexes all `.jsonl` conversation files
+- **RAG-Powered Semantic Search**: Uses sentence-transformers for embedding generation and ChromaDB for vector storage
+- **Keyword Search**: Fast SQLite-based metadata search for exact matches
+- **Hybrid Search**: Combines semantic similarity with keyword filtering for precise results
+- **Insight Report Generation**: Jinja2-templated reports with customizable formats
+- **Activity Timeline**: Chronological view of development patterns
+- **File Hotspot Analysis**: Identifies frequently modified files and patterns
+- **Tool Usage Analytics**: Tracks which Claude Code tools are used most
+- **Pattern Detection**: Discovers recurring development workflows
+- **Zero Manual Effort**: Fully automatic processing of existing conversations
+- **Incremental Updates**: Only processes new/modified conversations on subsequent runs
+- **Rich Search Results**: Returns ranked matches with context snippets
+
+### Features
+- SQLite for fast metadata queries and conversation storage
+- ChromaDB for vector similarity search
+- sentence-transformers for state-of-the-art embeddings (all-MiniLM-L6-v2 model)
+- Jinja2 templating for flexible report generation
+- Click-based CLI for user-friendly commands
+- Python 3.8+ compatibility
+- ~500MB disk space for 1,000 conversations
+- ~2GB RAM for embedding generation
+
+### Commands
+- `conversation-processor.py`: Parse and store conversation metadata
+- `rag_indexer.py`: Generate embeddings and build vector index
+- `search-conversations.py`: Perform semantic/keyword/hybrid searches
+- `insight-generator.py`: Create weekly summary reports
+
+### Known Limitations
+- Tested on 1-2 projects only (proof of concept phase)
+- Processing time scales with conversation count (~1-2 min per 1,000 conversations)
+- Embedding generation requires 2GB RAM (can be reduced with smaller models)
+- Search quality depends on conversation content richness
+- Report templates are basic (limited customization)
+- No incremental embedding updates (full reindex required for now)
+
+### Documentation
+- Comprehensive SKILL.md with usage instructions
+- README with detailed feature descriptions
+- Requirements file with Python dependencies
+- Template examples for custom reports
+- CLI help for all commands
+
+### Requirements
+- Python 3.8 or higher
+- sentence-transformers (~1.5GB model download on first run)
+- chromadb
+- jinja2
+- click
+- python-dateutil
+- ~500MB disk space for typical usage
+- ~2GB RAM for embedding generation
+
+## [Unreleased]
+
+### Planned Features
+- **Dashboard UI**: Interactive web interface for browsing conversations and insights
+- **Real-time Indexing**: Watch mode for automatic indexing of new conversations
+- **Advanced Analytics**: Success rate tracking, error pattern analysis, tool effectiveness metrics
+- **Custom Embeddings**: Support for different embedding models (OpenAI, Cohere, etc.)
+- **Export Formats**: CSV, JSON, PDF report generation
+- **Team Analytics**: Aggregate insights across team members
+- **Time-based Filters**: Search within date ranges
+- **Conversation Replay**: Step-through visualization of past conversations
+- **Recommendation Engine**: Suggest relevant past solutions for current problems
+
+### Under Consideration
+- Integration with external knowledge bases (Confluence, Notion)
+- Multi-project correlation analysis
+- LLM-powered insight generation (GPT-4 summaries)
+- Conversation quality scoring
+- Predictive analytics (suggest next steps)
+- Version control integration (link conversations to commits)
+- Privacy mode (exclude sensitive conversations)
+- Cloud sync for team collaboration

--- a/cc-insights/plugin.json
+++ b/cc-insights/plugin.json
@@ -1,0 +1,46 @@
+{
+  "name": "cc-insights",
+  "version": "2.0.0-beta",
+  "description": "RAG-powered conversation analysis and semantic search - automatically processes Claude Code conversation history and generates intelligent insight reports about development patterns",
+  "author": "Connor",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/cskiro/claudex/tree/main/cc-insights",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cskiro/claudex"
+  },
+  "keywords": [
+    "rag",
+    "semantic-search",
+    "analytics",
+    "insights",
+    "conversation-analysis",
+    "pattern-detection",
+    "chromadb"
+  ],
+  "requirements": {
+    "python": ">=3.8",
+    "packages": [
+      "sentence-transformers",
+      "chromadb",
+      "jinja2",
+      "click",
+      "python-dateutil"
+    ]
+  },
+  "components": {
+    "agents": [
+      {
+        "name": "cc-insights",
+        "manifestPath": "SKILL.md"
+      }
+    ]
+  },
+  "metadata": {
+    "category": "productivity",
+    "status": "beta",
+    "tested": "1-2 projects locally",
+    "diskSpace": "~500MB for 1,000 conversations",
+    "memory": "~2GB RAM for embedding generation"
+  }
+}

--- a/claude-md-auditor/plugin.json
+++ b/claude-md-auditor/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "claude-md-auditor",
+  "version": "1.0.0-beta",
+  "description": "Validates and audits CLAUDE.md configuration files for Claude Code - ensures compliance with schema standards and best practices for LLM configuration",
+  "author": "Connor",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/cskiro/claudex/tree/main/claude-md-auditor",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cskiro/claudex"
+  },
+  "keywords": [
+    "configuration",
+    "validation",
+    "claude-md",
+    "schema",
+    "best-practices",
+    "llm-config"
+  ],
+  "requirements": {
+    "python": ">=3.8"
+  },
+  "components": {
+    "agents": [
+      {
+        "name": "claude-md-auditor",
+        "manifestPath": "SKILL.md"
+      }
+    ]
+  },
+  "metadata": {
+    "category": "tooling",
+    "status": "beta",
+    "tested": "1-2 projects locally"
+  }
+}

--- a/codebase-auditor/CHANGELOG.md
+++ b/codebase-auditor/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog - Codebase Auditor
+
+All notable changes to the Codebase Auditor skill will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0-beta] - 2025-10-26
+
+### Added
+- Initial beta release of comprehensive codebase auditor
+- **Code Quality Analysis**: Cyclomatic complexity, code duplication, code smells detection
+- **Security Scanning**: OWASP Top 10 compliance checking, secret detection, CVE vulnerability scanning
+- **Test Coverage Analysis**: Coverage metrics, test distribution analysis, coverage gaps identification
+- **Dependency Management**: Vulnerability scanning, license compliance checking, outdated dependency detection
+- **Performance Analysis**: Build time optimization, runtime performance patterns, CI/CD pipeline analysis
+- **Technical Debt Assessment**: SQALE rating, debt categorization, remediation priority scoring
+- **Multiple Output Formats**: Markdown reports (human-readable), JSON reports (CI/CD integration), HTML dashboards (visualization)
+- **Prioritized Remediation Plans**: Actionable fix recommendations with effort estimates
+- **Standards Compliance**: Based on 2024-25 SDLC best practices (OWASP, WCAG, DORA metrics)
+
+### Features
+- Modular analyzer architecture for extensibility
+- Reference materials included for audit criteria
+- Severity matrix for issue prioritization
+- Example reports and remediation plans
+- Python 3.8+ compatibility
+
+### Known Limitations
+- Tested on 1-2 projects only (proof of concept phase)
+- Primary focus on Python/JavaScript/TypeScript codebases
+- Security scanning relies on static analysis (no runtime analysis)
+- Dependency vulnerability checking requires internet connection
+- Performance analysis focuses on common patterns (may miss project-specific issues)
+
+### Documentation
+- Comprehensive SKILL.md with usage instructions
+- README with detailed feature descriptions
+- Reference documentation for audit standards
+- Example reports in `examples/` directory
+
+### Requirements
+- Python 3.8 or higher
+- Standard Python libraries (no external dependencies for core functionality)
+- Git repository for version control analysis
+
+## [Unreleased]
+
+### Planned Features
+- Support for more languages (Go, Rust, Java, C#)
+- Integration with popular CI/CD platforms (GitHub Actions, GitLab CI, Jenkins)
+- Real-time monitoring mode for continuous auditing
+- Custom audit rule configuration
+- Team-specific severity thresholds
+- Historical trend analysis
+- Automated fix suggestions with code generation
+- IDE integration for real-time feedback
+
+### Under Consideration
+- Machine learning-based pattern detection
+- Cross-project comparative analysis
+- License compatibility checking
+- Architecture decision record (ADR) integration
+- Dependency graph visualization

--- a/codebase-auditor/plugin.json
+++ b/codebase-auditor/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "codebase-auditor",
+  "version": "1.0.0-beta",
+  "description": "Comprehensive static analysis tool that audits codebases for quality, security, and technical debt based on 2024-25 SDLC best practices (OWASP, WCAG, DORA)",
+  "author": "Connor",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/cskiro/claudex/tree/main/codebase-auditor",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cskiro/claudex"
+  },
+  "keywords": [
+    "audit",
+    "code-quality",
+    "security",
+    "testing",
+    "technical-debt",
+    "owasp",
+    "wcag",
+    "dora"
+  ],
+  "requirements": {
+    "python": ">=3.8"
+  },
+  "components": {
+    "agents": [
+      {
+        "name": "codebase-auditor",
+        "manifestPath": "SKILL.md"
+      }
+    ]
+  },
+  "metadata": {
+    "category": "analysis",
+    "status": "beta",
+    "tested": "1-2 projects locally"
+  }
+}

--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -1,0 +1,301 @@
+# Migration Guide: Manual to Marketplace Installation
+
+This guide helps you migrate from manual skill installation (copying files) to the new marketplace-based installation system for claudex skills.
+
+## Why Migrate?
+
+**Benefits of Marketplace Installation:**
+- ✅ **Automatic updates**: Get new features and bug fixes automatically
+- ✅ **Version management**: Pin specific versions for stability
+- ✅ **Team synchronization**: Same plugins for everyone via `.claude/settings.json`
+- ✅ **Easy discovery**: Browse all available plugins via `/plugin`
+- ✅ **Dependency resolution**: Future multi-plugin dependencies handled automatically
+- ✅ **Simplified maintenance**: No manual file copying or symlink management
+
+## Migration Steps
+
+### Step 1: Check Current Installation
+
+First, check if you have manually installed skills:
+
+```bash
+# Check global skills directory
+ls ~/.claude/skills/
+
+# Check project-local skills (in each project)
+ls .claude/skills/
+```
+
+If these directories contain `codebase-auditor`, `bulletproof-react-auditor`, `claude-md-auditor`, or `cc-insights`, you have manual installations that should be migrated.
+
+### Step 2: Remove Manual Installations
+
+**Global Skills (remove from home directory):**
+
+```bash
+# Remove all manually installed claudex skills
+rm -rf ~/.claude/skills/codebase-auditor
+rm -rf ~/.claude/skills/bulletproof-react-auditor
+rm -rf ~/.claude/skills/claude-md-auditor
+rm -rf ~/.claude/skills/cc-insights
+```
+
+**Project-Local Skills (remove from each project):**
+
+```bash
+# In each project directory with manual installations
+rm -rf .claude/skills/codebase-auditor
+rm -rf .claude/skills/bulletproof-react-auditor
+rm -rf .claude/skills/claude-md-auditor
+rm -rf .claude/skills/cc-insights
+
+# Optional: Remove the entire skills directory if it's empty
+rmdir .claude/skills/ 2>/dev/null || true
+```
+
+### Step 3: Add Marketplace
+
+In Claude Code, add the claudex marketplace:
+
+```bash
+/plugin marketplace add cskiro/claudex
+```
+
+You should see confirmation that the marketplace was added successfully.
+
+### Step 4: Install Skills via Marketplace
+
+**Option A: Browse and Install Interactively**
+
+```bash
+# Open the plugin browser
+/plugin
+
+# Select skills to install from the claudex marketplace
+# Follow the interactive prompts
+```
+
+**Option B: Install Directly**
+
+```bash
+# Install specific skills
+/plugin install codebase-auditor@claudex
+/plugin install bulletproof-react-auditor@claudex
+/plugin install claude-md-auditor@claudex
+/plugin install cc-insights@claudex
+```
+
+**Option C: Install All at Once (Recommended)**
+
+```bash
+/plugin install codebase-auditor@claudex bulletproof-react-auditor@claudex claude-md-auditor@claudex cc-insights@claudex
+```
+
+### Step 5: Verify Installation
+
+Test that your skills are working:
+
+```bash
+# In Claude Code, try invoking a skill
+# For example: "Audit this codebase"
+# Or: "Search my conversations about testing"
+```
+
+If the skill responds correctly, your migration is complete!
+
+### Step 6: Configure Team Auto-Install (Optional)
+
+For projects where you want all team members to have the same skills, add this to your project's `.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "claudex": {
+      "source": {
+        "source": "github",
+        "repo": "cskiro/claudex"
+      }
+    }
+  },
+  "enabledPlugins": [
+    "codebase-auditor@claudex",
+    "bulletproof-react-auditor@claudex",
+    "claude-md-auditor@claudex",
+    "cc-insights@claudex"
+  ]
+}
+```
+
+**How it works:**
+1. Commit `.claude/settings.json` to your repository
+2. When team members clone/pull and trust the repository folder
+3. Claude Code automatically installs the marketplace and plugins
+4. Everyone has the same skills with zero manual setup
+
+## Troubleshooting
+
+### Issue: Skills not showing up after installation
+
+**Solution:**
+```bash
+# Refresh marketplace metadata
+/plugin marketplace update claudex
+
+# Verify installation
+/plugin list
+```
+
+### Issue: Old manual skills still responding
+
+**Solution:**
+Claude Code checks `.claude/skills/` before marketplace plugins. Ensure you've removed all manual installations:
+
+```bash
+# Double-check removal
+ls -la ~/.claude/skills/
+ls -la .claude/skills/
+
+# Remove any remaining skills
+rm -rf ~/.claude/skills/codebase-auditor
+rm -rf .claude/skills/codebase-auditor
+```
+
+Then restart Claude Code if necessary.
+
+### Issue: Marketplace not found
+
+**Solution:**
+Ensure you're using the correct syntax:
+
+```bash
+# Correct format
+/plugin marketplace add cskiro/claudex
+
+# If using SSH authentication
+/plugin marketplace add git@github.com:cskiro/claudex.git
+```
+
+### Issue: cc-insights dependencies missing
+
+**Solution:**
+The cc-insights skill requires Python dependencies. Install them manually:
+
+```bash
+# Navigate to the installed plugin directory
+cd ~/.claude/plugins/cc-insights@claudex/
+
+# Install Python requirements
+pip3 install -r requirements.txt
+```
+
+Or use the automatic installation script (coming in future release):
+```bash
+/plugin install cc-insights@claudex --install-deps
+```
+
+## Rollback (If Needed)
+
+If you need to temporarily roll back to manual installation:
+
+```bash
+# Remove marketplace plugins
+/plugin uninstall codebase-auditor@claudex
+/plugin marketplace remove claudex
+
+# Reinstall manually (legacy method)
+git clone https://github.com/cskiro/claudex.git
+cp -r claudex/codebase-auditor ~/.claude/skills/
+```
+
+**Note**: We strongly recommend using the marketplace system. Manual installation is deprecated and may not be supported in future Claude Code versions.
+
+## Version Pinning (Advanced)
+
+For production environments, you may want to pin specific versions:
+
+```json
+{
+  "enabledPlugins": [
+    "codebase-auditor@claudex@1.0.0-beta",
+    "cc-insights@claudex@2.0.0-beta"
+  ]
+}
+```
+
+**Benefits:**
+- Prevents unexpected changes from auto-updates
+- Ensures reproducible builds in CI/CD
+- Allows gradual rollout of new versions
+
+**Drawbacks:**
+- Must manually update to get bug fixes
+- Can miss important security updates
+
+**Recommendation**: Pin versions in production, use latest in development.
+
+## FAQ
+
+### Q: Will my existing skill data be lost?
+
+**A**: No. Skills use standard directories for generated data:
+- Audit reports are saved to your project directories
+- cc-insights data is in `~/.cc-insights/`
+- CLAUDE.md auditor doesn't persist data
+
+Your data remains intact after migration.
+
+### Q: Can I use both manual and marketplace installation?
+
+**A**: Not recommended. Claude Code prioritizes `.claude/skills/` over marketplace plugins, which can cause confusion about which version is active. Choose one method.
+
+### Q: How do I update plugins after migration?
+
+**A**: Marketplace plugins update automatically by default. You can also manually trigger updates:
+
+```bash
+# Update all plugins
+/plugin update
+
+# Update specific marketplace
+/plugin marketplace update claudex
+```
+
+### Q: What if I have local modifications to a skill?
+
+**A**: Marketplace plugins overwrite local changes. If you've customized a skill:
+
+1. Fork the claudex repository
+2. Add your fork as a separate marketplace
+3. Maintain your custom version there
+
+Or continue using manual installation for that specific skill.
+
+### Q: Do I need internet access for marketplace plugins?
+
+**A**: Yes, for initial installation and updates. Once installed, skills work offline (except cc-insights web search features).
+
+## Support
+
+If you encounter issues during migration:
+
+1. Check this guide's [Troubleshooting](#troubleshooting) section
+2. Review the [main README](../README.md) for updated instructions
+3. Open an issue: [github.com/cskiro/claudex/issues](https://github.com/cskiro/claudex/issues)
+
+## Migration Checklist
+
+Use this checklist to track your migration:
+
+- [ ] Checked for existing manual installations (global and project-local)
+- [ ] Removed all manual skill installations from `~/.claude/skills/`
+- [ ] Removed all manual skill installations from project `.claude/skills/`
+- [ ] Added claudex marketplace: `/plugin marketplace add cskiro/claudex`
+- [ ] Installed required skills via `/plugin install`
+- [ ] Verified skills work by testing invocation
+- [ ] (Optional) Added team configuration to `.claude/settings.json`
+- [ ] (Optional) Committed `.claude/settings.json` to repository
+- [ ] Informed team members about the migration
+
+---
+
+**Need help?** Open an issue at [github.com/cskiro/claudex/issues](https://github.com/cskiro/claudex/issues) with the "migration" label.


### PR DESCRIPTION
## Summary

Implements comprehensive marketplace support following Anthropic's official plugin marketplace specification. This enables users to install claudex skills via `/plugin marketplace add cskiro/claudex` instead of manual file copying.

## Key Changes

### Marketplace Configuration
- ✅ `.claude-plugin/marketplace.json`: Official marketplace catalog with 4 plugins
- ✅ `.claude-plugin/validate-marketplace.py`: Python validation script for marketplace integrity

### Plugin Manifests
- ✅ `codebase-auditor/plugin.json`: Plugin manifest with requirements and components
- ✅ `bulletproof-react-auditor/plugin.json`: Plugin manifest for React auditor
- ✅ `claude-md-auditor/plugin.json`: Plugin manifest for CLAUDE.md validator
- ✅ `cc-insights/plugin.json`: Plugin manifest with Python dependencies

### Documentation
- ✅ `docs/MIGRATION_GUIDE.md`: Comprehensive guide for migrating from manual to marketplace installation
- ✅ `codebase-auditor/CHANGELOG.md`: Version history and planned features
- ✅ `cc-insights/CHANGELOG.md`: Version history for conversation insights skill

### CI/CD
- ✅ `.github/workflows/validate-marketplace.yml`: GitHub Actions workflow for automated validation

### Updated
- ✅ `README.md`: New Quick Start section with marketplace installation instructions, team configuration guide, and legacy manual installation in collapsible section

## Migration Path

Users with existing manual installations can:
1. Remove old `~/.claude/skills/` directories
2. Add marketplace: `/plugin marketplace add cskiro/claudex`
3. Install plugins: `/plugin install codebase-auditor@claudex`
4. (Optional) Configure team auto-install in `.claude/settings.json`

See `docs/MIGRATION_GUIDE.md` for detailed migration instructions with troubleshooting.

## Testing

✅ **All validations pass:**
- Marketplace structure valid (4 plugins)
- All plugin.json files present and valid JSON
- All SKILL.md files present with content
- GitHub Actions workflow configured
- Local validation script functional

```bash
$ python3 .claude-plugin/validate-marketplace.py
🔍 Validating claudex marketplace...

✅ Validation passed!
   Marketplace: claudex
   Plugins: 4
   Warnings: 0
```

## Benefits

### For Users
- **Simpler Installation**: `/plugin marketplace add cskiro/claudex` instead of manual copying
- **Auto-Updates**: Get new features automatically
- **Easy Discovery**: Browse all available plugins via `/plugin`
- **Version Management**: Pin specific versions for stability

### For Teams
- **Standardization**: Consistent plugin setup via `.claude/settings.json`
- **Auto-Install**: New team members get correct plugins on repository trust
- **Version Control**: Track plugin dependencies in version control

## Files Changed

```
11 files changed, 1,205 insertions(+), 10 deletions(-)
```

- `.claude-plugin/marketplace.json` (91 lines)
- `.claude-plugin/validate-marketplace.py` (303 lines)
- `.github/workflows/validate-marketplace.yml` (138 lines)
- `README.md` (+64 lines)
- 4 × `plugin.json` files (36-46 lines each)
- 2 × `CHANGELOG.md` files (64-87 lines each)
- `docs/MIGRATION_GUIDE.md` (301 lines)

## References

- [Anthropic Plugin Marketplace Docs](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces)
- [Anthropic Skills Repository](https://github.com/anthropics/skills)
- [Team Setup Guide](https://skywork.ai/blog/claude-code-plugin-standardization-team-guide/)

## Next Steps

After merge:
1. Test marketplace installation: `/plugin marketplace add cskiro/claudex`
2. Install a skill: `/plugin install codebase-auditor@claudex`
3. Verify GitHub Actions workflow runs successfully
4. Announce to users about the new installation method

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)