### PR TITLE
fix: Correct hooks.json schema and marketplace path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Skills and hooks for Claude Code - code quality analysis, testing automation, productivity tools, and DevOps workflows",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "homepage": "https://github.com/cskiro/claudex"
   },
   "plugins": [
@@ -80,7 +80,7 @@
       "description": "Productivity enhancement hooks for automated insight extraction and learning",
       "source": "./",
       "strict": false,
-      "hooks": "./hooks/extract-explanatory-insights/hooks.json",
+      "hooks": "./hooks/hooks.json",
       "category": "productivity",
       "version": "0.1.0"
     }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,11 +1,14 @@
 {
   "$schema": "https://anthropic.com/claude-code/hooks.schema.json",
-  "Stop": [
-    {
-      "matcher": "",
-      "type": "command",
-      "command": "${CLAUDE_PLUGIN_ROOT}/hooks/extract-explanatory-insights.sh",
-      "description": "Extract ★ Insight blocks from Claude Code responses after agent stops"
-    }
-  ]
+  "description": "Productivity enhancement hooks for automated insight extraction and learning",
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "type": "command",
+        "command": "${CLAUDE_PLUGIN_ROOT}/hooks/extract-explanatory-insights.sh",
+        "description": "Extract ★ Insight blocks from Claude Code responses after agent stops"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Fixed hooks.json schema to include root-level `hooks` object wrapper per Claude Code specification
- Corrected marketplace.json hooks path from non-existent `./hooks/extract-explanatory-insights/hooks.json` to `./hooks/hooks.json`
- Added description field to hooks.json for documentation clarity
- Validated structure against official Claude Code documentation

## Problem
Plugin loading was failing with validation errors:
```
Failed to load hooks from /Users/connor/.claude/plugins/marketplaces/claudex/hooks/hooks.json: 
[{ "code": "invalid_type", "expected": "object", "received": "undefined", "path": ["hooks"], "message": "Required" }]
```

## Root Cause
The hooks.json file had event names (like `Stop`) at the root level instead of wrapped in a `hooks` object, violating the Claude Code plugin hooks schema.

## Solution
Restructured hooks.json to match the official schema:
```json
{
  "description": "...",
  "hooks": {
    "Stop": [...]
  }
}
```

## Test Plan
- [x] Verified schema matches Claude Code documentation
- [x] Confirmed hooks path exists in repository
- [ ] Test plugin installation after merge

## References
- Claude Code hooks documentation: https://code.claude.com/docs/en/hooks.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)