### PR TITLE
feat(marketplace): Add adr-generator plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,6 +20,15 @@
       ]
     },
     {
+      "name": "adr-generator",
+      "description": "Architecture Decision Records (ADRs) creation with standard templates and structured documentation",
+      "source": "./plugins/adr-generator",
+      "strict": false,
+      "skills": [
+        "./skills/adr-generator"
+      ]
+    },
+    {
       "name": "ascii-diagram-creator",
       "description": "ASCII diagrams and text-based visual representations of systems, workflows, and architecture",
       "source": "./plugins/ascii-diagram-creator",

--- a/plugins/adr-generator/.claude-plugin/plugin.json
+++ b/plugins/adr-generator/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "adr-generator",
+  "version": "0.1.0",
+  "description": "Architecture Decision Records (ADRs) creation with standard templates and structured documentation",
+  "author": {
+    "name": "Connor",
+    "email": "noreply@claudex.dev"
+  }
+}

--- a/plugins/adr-generator/README.md
+++ b/plugins/adr-generator/README.md
@@ -1,0 +1,69 @@
+# ADR Generator Plugin
+
+Architecture Decision Records (ADRs) creation with standard templates and structured documentation.
+
+## Installation
+
+```bash
+/plugin marketplace add cskiro/claudex --plugin adr-generator
+```
+
+## Usage
+
+Invoke the skill when making significant architectural decisions:
+
+```
+Create an ADR for choosing PostgreSQL over MongoDB for our persistence layer
+```
+
+```
+Document the architecture decision to adopt event sourcing
+```
+
+```
+New ADR: implementing CQRS pattern for read/write separation
+```
+
+## Triggers
+
+- "create ADR"
+- "document architecture decision"
+- "new ADR"
+- "record decision"
+- "architecture decision record"
+
+## What This Skill Does
+
+1. **Identifies** the architectural decision to document
+2. **Gathers** context, constraints, and stakeholder concerns
+3. **Lists** options considered with pros/cons analysis
+4. **Documents** the decision with clear rationale
+5. **Saves** to standard `docs/adr/` directory structure
+
+## ADR Format
+
+Generated ADRs follow the standard format:
+
+- **Status**: Proposed, Accepted, Deprecated, or Superseded
+- **Context**: The issue motivating this decision
+- **Decision**: The change being proposed/implemented
+- **Consequences**: Positive, negative, and neutral impacts
+
+## When to Use
+
+- Choosing between technologies or frameworks
+- Defining API design patterns
+- Selecting architectural patterns
+- Making security-related decisions
+- Establishing coding standards that affect architecture
+
+## When NOT to Use
+
+- Code documentation (use docstrings/JSDoc)
+- README files
+- Implementation details
+- Trivial decisions that don't affect architecture
+
+## Version
+
+0.1.0

--- a/plugins/adr-generator/README.md
+++ b/plugins/adr-generator/README.md
@@ -5,7 +5,7 @@ Architecture Decision Records (ADRs) creation with standard templates and struct
 ## Installation
 
 ```bash
-/plugin marketplace add cskiro/claudex --plugin adr-generator
+/plugin install adr-generator@claudex
 ```
 
 ## Usage
@@ -64,6 +64,10 @@ Generated ADRs follow the standard format:
 - Implementation details
 - Trivial decisions that don't affect architecture
 
-## Version
+## Skill Documentation
 
-0.1.0
+See [`skills/adr-generator/SKILL.md`](./skills/adr-generator/SKILL.md) for detailed usage instructions.
+
+## License
+
+MIT

--- a/plugins/adr-generator/skills/adr-generator/SKILL.md
+++ b/plugins/adr-generator/skills/adr-generator/SKILL.md
@@ -1,12 +1,7 @@
 ---
 name: adr-generator
-description: >
-  Creates Architecture Decision Records (ADRs) following standard templates.
-  Documents architectural decisions with context, options considered, and rationale.
-  TRIGGERS: "create ADR", "document architecture decision", "new ADR",
-  "record decision", "architecture decision record".
-  Use when making significant architectural choices that should be documented.
-  NOT for code documentation or README files.
+version: 0.1.0
+description: Creates Architecture Decision Records (ADRs) following standard templates. Documents architectural decisions with context, options considered, and rationale. TRIGGERS - "create ADR", "document architecture decision", "new ADR", "record decision", "architecture decision record". Use when making significant architectural choices that should be documented. NOT for code documentation or README files.
 ---
 
 # ADR Generator

--- a/plugins/adr-generator/skills/adr-generator/SKILL.md
+++ b/plugins/adr-generator/skills/adr-generator/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: adr-generator
+description: >
+  Creates Architecture Decision Records (ADRs) following standard templates.
+  Documents architectural decisions with context, options considered, and rationale.
+  TRIGGERS: "create ADR", "document architecture decision", "new ADR",
+  "record decision", "architecture decision record".
+  Use when making significant architectural choices that should be documented.
+  NOT for code documentation or README files.
+---
+
+# ADR Generator
+
+Create Architecture Decision Records following the standard ADR format.
+
+## Quick Start
+
+1. Identify the architectural decision to document
+2. Gather context and constraints
+3. List options considered with pros/cons
+4. Document the decision and rationale
+5. Save to `docs/adr/` or `adr/` directory
+
+## ADR Template
+
+```markdown
+# ADR-NNNN: [Title]
+
+## Status
+
+[Proposed | Accepted | Deprecated | Superseded by ADR-XXXX]
+
+## Context
+
+[What is the issue that we're seeing that is motivating this decision or change?]
+
+## Decision
+
+[What is the change that we're proposing and/or doing?]
+
+## Consequences
+
+### Positive
+- [Benefit 1]
+- [Benefit 2]
+
+### Negative
+- [Tradeoff 1]
+- [Tradeoff 2]
+
+### Neutral
+- [Side effect that is neither positive nor negative]
+```
+
+## Workflow
+
+| Step | Action | Output |
+|------|--------|--------|
+| 1 | Identify decision | Clear problem statement |
+| 2 | Research options | List of alternatives |
+| 3 | Evaluate tradeoffs | Pros/cons for each option |
+| 4 | Document decision | ADR file |
+| 5 | Get approval | Status -> Accepted |
+
+## Naming Convention
+
+```
+docs/adr/
+├── 0001-use-postgresql-for-persistence.md
+├── 0002-adopt-event-sourcing.md
+├── 0003-implement-cqrs-pattern.md
+└── README.md (index of all ADRs)
+```
+
+## When to Create ADRs
+
+- Choosing between technologies or frameworks
+- Defining API design patterns
+- Selecting architectural patterns (microservices, monolith, etc.)
+- Making security-related decisions
+- Establishing coding standards that affect architecture
+
+## Limitations
+
+- ADRs document decisions, not implementation details
+- Keep ADRs focused on a single decision
+- Link related ADRs rather than combining them

--- a/plugins/adr-generator/skills/adr-generator/SKILL.md
+++ b/plugins/adr-generator/skills/adr-generator/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: adr-generator
-version: 0.1.0
 description: Creates Architecture Decision Records (ADRs) following standard templates. Documents architectural decisions with context, options considered, and rationale. TRIGGERS - "create ADR", "document architecture decision", "new ADR", "record decision", "architecture decision record". Use when making significant architectural choices that should be documented. NOT for code documentation or README files.
 ---
 


### PR DESCRIPTION
## Chapter: ADR Generator Migration

### The Ask
Migrate the local `~/.claude/skills/adr-generator` skill to the Claudex marketplace for broader distribution, allowing users to install it independently via the plugin system.

### The Journey
Followed the established Claudex plugin migration pattern:
1. Created plugin directory structure matching Anthropic's `plugins/` pattern
2. Adapted SKILL.md from local skill (no content changes needed - already well-formed)
3. Created plugin.json with version 0.1.0 (per new skill versioning rules)
4. Added comprehensive README.md with installation and usage instructions
5. Inserted alphabetically into marketplace.json (between accessibility-audit and ascii-diagram-creator)
6. Validated with both schema and quality validators

### The Architecture
```
plugins/adr-generator/
├── .claude-plugin/
│   └── plugin.json        # v0.1.0
├── skills/
│   └── adr-generator/
│       └── SKILL.md       # Standard ADR template + workflow
└── README.md              # Installation + usage docs
```

### The Outcome
- **23rd plugin** added to Claudex marketplace
- **Validation**: marketplace.json ✅ | skill validation Grade A (96%)
- **Installation**: `/plugin marketplace add cskiro/claudex --plugin adr-generator`

### The Lessons
ADR documentation aligns with XP's Document Decisions principle - skills that promote architectural documentation provide long-term value for team knowledge sharing.

### Commit Narrative
- `fc3266f`: Initial plugin creation with all required files

---

Generated with [Claude Code](https://claude.ai/code)