### PR TITLE
fix(marketplace): Resolve plugin manifest conflicts and hook schema

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Skills and hooks for Claude Code - code quality analysis, testing automation, productivity tools, and DevOps workflows",
-    "version": "6.1.0",
+    "version": "6.2.0",
     "homepage": "https://github.com/cskiro/claudex"
   },
   "plugins": [
@@ -14,209 +14,139 @@
       "name": "accessibility-audit",
       "description": "WCAG compliance auditing, screen reader testing, keyboard navigation validation, and color contrast analysis",
       "source": "./plugins/accessibility-audit",
-      "strict": false,
-      "skills": [
-        "./skills/accessibility-audit"
-      ]
+      "strict": true
     },
     {
       "name": "adr-generator",
       "description": "Architecture Decision Records (ADRs) creation with standard templates and structured documentation",
       "source": "./plugins/adr-generator",
-      "strict": false,
-      "skills": [
-        "./skills/adr-generator"
-      ]
+      "strict": true
     },
     {
       "name": "ascii-diagram-creator",
       "description": "ASCII diagrams and text-based visual representations of systems, workflows, and architecture",
       "source": "./plugins/ascii-diagram-creator",
-      "strict": false,
-      "skills": [
-        "./skills/ascii-diagram-creator"
-      ]
+      "strict": true
     },
     {
       "name": "benchmark-report-creator",
       "description": "Research reports, experiment writeups, and empirical study documentation for LLM benchmarking",
       "source": "./plugins/benchmark-report-creator",
-      "strict": false,
-      "skills": [
-        "./skills/benchmark-report-creator"
-      ]
+      "strict": true
     },
     {
       "name": "bulletproof-react-auditor",
       "description": "React project structure auditing using Bulletproof React patterns and anti-pattern detection",
       "source": "./plugins/bulletproof-react-auditor",
-      "strict": false,
-      "skills": [
-        "./skills/bulletproof-react-auditor"
-      ]
+      "strict": true
     },
     {
       "name": "cc-insights",
       "description": "RAG-powered Claude Code conversation analysis, development pattern search, and activity reports",
       "source": "./plugins/cc-insights",
-      "strict": false,
-      "skills": [
-        "./skills/cc-insights"
-      ],
-      "hooks": "./hooks/hooks.json"
+      "strict": true
     },
     {
       "name": "claude-md-auditor",
       "description": "CLAUDE.md configuration validation against Anthropic documentation and best practices",
       "source": "./plugins/claude-md-auditor",
-      "strict": false,
-      "skills": [
-        "./skills/claude-md-auditor"
-      ]
+      "strict": true
     },
     {
       "name": "codebase-auditor",
       "description": "Code quality auditing, security scans, technical debt assessment, and DORA metrics tracking",
       "source": "./plugins/codebase-auditor",
-      "strict": false,
-      "skills": [
-        "./skills/codebase-auditor"
-      ]
+      "strict": true
     },
     {
       "name": "e2e-testing",
       "description": "End-to-end testing setup with Playwright, visual analysis, and browser automation",
       "source": "./plugins/e2e-testing",
-      "strict": false,
-      "skills": [
-        "./skills/e2e-testing"
-      ]
+      "strict": true
     },
     {
       "name": "git-worktree-setup",
       "description": "Git worktree automation for parallel branch development and multiple Claude Code sessions",
       "source": "./plugins/git-worktree-setup",
-      "strict": false,
-      "skills": [
-        "./skills/git-worktree-setup"
-      ]
+      "strict": true
     },
     {
       "name": "github-repo-setup",
       "description": "GitHub repository creation with best practices and project templates",
       "source": "./plugins/github-repo-setup",
-      "strict": false,
-      "skills": [
-        "./skills/github-repo-setup"
-      ]
+      "strict": true
     },
     {
       "name": "insight-skill-generator",
       "description": "Transforms Claude Code explanatory insights into reusable, production-ready skills",
       "source": "./plugins/insight-skill-generator",
-      "strict": false,
-      "skills": [
-        "./skills/insight-skill-generator"
-      ]
+      "strict": true
     },
     {
       "name": "json-outputs-implementer",
       "description": "Anthropic API JSON outputs implementation with structured data extraction",
       "source": "./plugins/json-outputs-implementer",
-      "strict": false,
-      "skills": [
-        "./skills/json-outputs-implementer"
-      ]
+      "strict": true
     },
     {
       "name": "mcp-server-creator",
       "description": "Model Context Protocol server generation for AI application integrations",
       "source": "./plugins/mcp-server-creator",
-      "strict": false,
-      "skills": [
-        "./skills/mcp-server-creator"
-      ]
+      "strict": true
     },
     {
       "name": "mutation-testing",
       "description": "Test suite quality validation through mutation testing and mutation score analysis",
       "source": "./plugins/mutation-testing",
-      "strict": false,
-      "skills": [
-        "./skills/mutation-testing"
-      ]
+      "strict": true
     },
     {
       "name": "otel-monitoring-setup",
       "description": "OpenTelemetry monitoring setup for Claude Code usage tracking and cost analysis",
       "source": "./plugins/otel-monitoring-setup",
-      "strict": false,
-      "skills": [
-        "./skills/otel-monitoring-setup"
-      ]
+      "strict": true
     },
     {
       "name": "react-project-scaffolder",
       "description": "React project scaffolding with modern tooling - Vite sandbox and Next.js enterprise modes",
       "source": "./plugins/react-project-scaffolder",
-      "strict": false,
-      "skills": [
-        "./skills/react-project-scaffolder"
-      ]
+      "strict": true
     },
     {
       "name": "semantic-release-tagger",
       "description": "Automated git tagging and release management using conventional commits",
       "source": "./plugins/semantic-release-tagger",
-      "strict": false,
-      "skills": [
-        "./skills/semantic-release-tagger"
-      ]
+      "strict": true
     },
     {
       "name": "skill-creator",
       "description": "Claude Code skill generation following Claudex marketplace standards",
       "source": "./plugins/skill-creator",
-      "strict": false,
-      "skills": [
-        "./skills/skill-creator"
-      ]
+      "strict": true
     },
     {
       "name": "skill-isolation-tester",
       "description": "Skill validation in isolation environments before public release",
       "source": "./plugins/skill-isolation-tester",
-      "strict": false,
-      "skills": [
-        "./skills/skill-isolation-tester"
-      ]
+      "strict": true
     },
     {
       "name": "strict-tool-implementer",
       "description": "Anthropic API strict tool use implementation for guaranteed schema compliance",
       "source": "./plugins/strict-tool-implementer",
-      "strict": false,
-      "skills": [
-        "./skills/strict-tool-implementer"
-      ]
+      "strict": true
     },
     {
       "name": "structured-outputs-advisor",
       "description": "Expert advisor for choosing between Anthropic JSON outputs and strict tool use",
       "source": "./plugins/structured-outputs-advisor",
-      "strict": false,
-      "skills": [
-        "./skills/structured-outputs-advisor"
-      ]
+      "strict": true
     },
     {
       "name": "sub-agent-creator",
       "description": "Specialized Claude Code sub-agent creation following Anthropic patterns",
       "source": "./plugins/sub-agent-creator",
-      "strict": false,
-      "skills": [
-        "./skills/sub-agent-creator"
-      ]
+      "strict": true
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,6 @@ claudex/
 │   └── validate-skills.py         # Skill quality validation
 ├── plugins/                       # 23 plugins (1 per skill)
 │   ├── accessibility-audit/
-│   │   ├── .claude-plugin/
-│   │   │   └── plugin.json
 │   │   ├── skills/
 │   │   │   └── accessibility-audit/
 │   │   │       ├── SKILL.md
@@ -40,8 +38,6 @@ claudex/
 │   │   │       └── CHANGELOG.md
 │   │   └── README.md
 │   ├── cc-insights/               # Includes hooks
-│   │   ├── .claude-plugin/
-│   │   │   └── plugin.json
 │   │   ├── skills/
 │   │   │   └── cc-insights/
 │   │   ├── hooks/
@@ -57,13 +53,13 @@ claudex/
 **Required structure for every plugin:**
 ```
 plugin-name/
-├── .claude-plugin/
-│   └── plugin.json        # Plugin metadata
 ├── skills/
 │   └── skill-name/
 │       └── SKILL.md       # Agent manifest (frontmatter + workflow)
 └── README.md              # Plugin documentation
 ```
+
+Note: Plugin metadata (name, description) lives in marketplace.json only. No per-plugin plugin.json files are needed.
 
 **Optional directories within skill:**
 ```
@@ -82,11 +78,13 @@ skill-name/
 ```json
 {
   "name": "claudex",
-  "version": "6.1.0",
-  "description": "Skills and hooks for Claude Code",
   "owner": {
     "name": "Connor",
     "email": "noreply@claudex.dev"
+  },
+  "metadata": {
+    "version": "6.2.0",
+    "description": "Skills and hooks for Claude Code"
   },
   "plugins": [
     {
@@ -98,36 +96,30 @@ skill-name/
 }
 ```
 
+**Auto-Discovery**: Claude Code automatically discovers components from the plugin's directory structure:
+- `skills/` - Skill definitions (SKILL.md files)
+- `hooks/` - Hook configurations (hooks.json)
+- `agents/` - Agent definitions
+- `commands/` - Custom commands
+
+Do NOT add `strict`, `skills`, or `hooks` fields to marketplace entries - Claude Code auto-discovers these from directory structure.
+
 ### Adding a New Skill/Plugin
 
 1. **Create plugin directory**:
    ```bash
-   mkdir -p plugins/skill-name/.claude-plugin
    mkdir -p plugins/skill-name/skills/skill-name
    ```
 
-2. **Create plugin.json**:
-   ```json
-   {
-     "name": "skill-name",
-     "version": "1.0.0",
-     "description": "Brief description",
-     "author": {
-       "name": "Connor",
-       "email": "noreply@claudex.dev"
-     }
-   }
-   ```
-
-3. **Create skill files**:
+2. **Create skill files**:
    - `skills/skill-name/SKILL.md` with frontmatter
 
-4. **Create plugin README.md**
+3. **Create plugin README.md**
 
-5. **Update marketplace.json**:
-   - Add plugin entry to `plugins` array
+4. **Update marketplace.json**:
+   - Add plugin entry to `plugins` array with `name`, `description`, and `source`
 
-6. **Validate**:
+5. **Validate**:
    ```bash
    python3 scripts/validate-marketplace.py
    python3 scripts/validate-skills.py plugins/skill-name
@@ -243,7 +235,15 @@ git push origin marketplace@X.Y.Z
 
 ## Marketplace Version History
 
-Current version: **6.1.0**
+Current version: **6.2.0**
+
+### Version 6.2.0
+- **FIX**: Removed all plugin.json files from plugins (single source of truth)
+- **FIX**: Fixed cc-insights hooks.json to use correct Anthropic schema format
+- Eliminated dual-manifest conflict (marketplace.json + plugin.json)
+- Plugin metadata now lives exclusively in marketplace.json
+- Resolves "Plugin has conflicting manifests" and hook load errors from `/doctor`
+- 23 plugins (1 per skill)
 
 ### Version 6.1.0
 - Added adr-generator plugin for Architecture Decision Records

--- a/README.md
+++ b/README.md
@@ -28,19 +28,17 @@ Follows Anthropic's official `anthropics/claude-code/plugins/` pattern:
 ```
 claudex/
 ├── .claude-plugin/
-│   └── marketplace.json        # Plugin registry (single source of truth)
-├── plugins/                    # 22 plugins (1 per skill)
+│   └── marketplace.json        # Single source of truth for all plugin metadata
+├── plugins/                    # 23 plugins (1 per skill)
 │   ├── accessibility-audit/
-│   │   ├── .claude-plugin/
-│   │   │   └── plugin.json
 │   │   ├── skills/
 │   │   │   └── accessibility-audit/
+│   │   │       └── SKILL.md
 │   │   └── README.md
 │   ├── cc-insights/            # Includes hooks
-│   │   ├── .claude-plugin/
-│   │   │   └── plugin.json
 │   │   ├── skills/
 │   │   │   └── cc-insights/
+│   │   │       └── SKILL.md
 │   │   ├── hooks/
 │   │   │   ├── hooks.json
 │   │   │   └── extract-explanatory-insights.sh
@@ -209,7 +207,7 @@ Apache 2.0
 ---
 
 **Maintained by**: Connor
-**Current Version**: v6.0.0
-**Last Updated**: 2026-01-24
+**Current Version**: v6.2.0
+**Last Updated**: 2026-02-04
 
 *Skills and hooks for extending Claude Code capabilities across the software development lifecycle.*

--- a/plugins/accessibility-audit/.claude-plugin/plugin.json
+++ b/plugins/accessibility-audit/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "accessibility-audit",
-  "version": "1.0.0",
-  "description": "WCAG compliance auditing, screen reader testing, keyboard navigation validation, and color contrast analysis for React/TypeScript applications",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/adr-generator/.claude-plugin/plugin.json
+++ b/plugins/adr-generator/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "adr-generator",
-  "version": "0.1.0",
-  "description": "Architecture Decision Records (ADRs) creation with standard templates and structured documentation",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/ascii-diagram-creator/.claude-plugin/plugin.json
+++ b/plugins/ascii-diagram-creator/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "ascii-diagram-creator",
-  "version": "1.0.0",
-  "description": "ASCII diagrams and text-based visual representations of systems, workflows, architecture, and relationships",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/benchmark-report-creator/.claude-plugin/plugin.json
+++ b/plugins/benchmark-report-creator/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "benchmark-report-creator",
-  "version": "1.0.0",
-  "description": "Research reports, experiment writeups, technical whitepapers, and empirical study documentation for LLM benchmarking",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/bulletproof-react-auditor/.claude-plugin/plugin.json
+++ b/plugins/bulletproof-react-auditor/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "bulletproof-react-auditor",
-  "version": "1.0.0",
-  "description": "React project structure auditing using Bulletproof React patterns, anti-pattern detection, and feature-sliced architecture guidance",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/cc-insights/.claude-plugin/plugin.json
+++ b/plugins/cc-insights/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "cc-insights",
-  "version": "1.0.0",
-  "description": "RAG-powered Claude Code conversation analysis, development pattern search, and activity report generation",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/cc-insights/hooks/hooks.json
+++ b/plugins/cc-insights/hooks/hooks.json
@@ -1,12 +1,15 @@
 {
-  "hooks": [
-    {
-      "event": "Stop",
-      "command": [
-        "bash",
-        "./hooks/extract-explanatory-insights.sh"
-      ],
-      "description": "Extracts ★ Insight blocks from Claude responses and saves to docs/lessons-learned/"
-    }
-  ]
+  "description": "Extracts ★ Insight blocks from Claude responses and saves to docs/lessons-learned/",
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/extract-explanatory-insights.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/claude-md-auditor/.claude-plugin/plugin.json
+++ b/plugins/claude-md-auditor/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "claude-md-auditor",
-  "version": "1.0.0",
-  "description": "CLAUDE.md configuration validation against Anthropic documentation and community best practices",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/codebase-auditor/.claude-plugin/plugin.json
+++ b/plugins/codebase-auditor/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "codebase-auditor",
-  "version": "1.0.0",
-  "description": "Code quality auditing, security scans, technical debt assessment, production readiness review, and DORA metrics tracking",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/e2e-testing/.claude-plugin/plugin.json
+++ b/plugins/e2e-testing/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "e2e-testing",
-  "version": "1.0.0",
-  "description": "End-to-end testing setup with Playwright, LLM-powered visual analysis, screenshot comparison, and browser automation",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/git-worktree-setup/.claude-plugin/plugin.json
+++ b/plugins/git-worktree-setup/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "git-worktree-setup",
-  "version": "1.0.0",
-  "description": "Git worktree automation for parallel branch development and multiple Claude Code sessions",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/github-repo-setup/.claude-plugin/plugin.json
+++ b/plugins/github-repo-setup/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "github-repo-setup",
-  "version": "1.0.0",
-  "description": "GitHub repository creation with best practices - quick public repos, enterprise-grade workflows, and project templates",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/insight-skill-generator/.claude-plugin/plugin.json
+++ b/plugins/insight-skill-generator/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "insight-skill-generator",
-  "version": "1.0.0",
-  "description": "Transforms Claude Code explanatory insights from docs/lessons-learned/ into reusable, production-ready skills",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/json-outputs-implementer/.claude-plugin/plugin.json
+++ b/plugins/json-outputs-implementer/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "json-outputs-implementer",
-  "version": "1.0.0",
-  "description": "Anthropic API JSON outputs implementation with structured data extraction and schema validation",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/mcp-server-creator/.claude-plugin/plugin.json
+++ b/plugins/mcp-server-creator/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "mcp-server-creator",
-  "version": "1.0.0",
-  "description": "Model Context Protocol server generation for connecting AI applications to external data sources, tools, and workflows",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/mutation-testing/.claude-plugin/plugin.json
+++ b/plugins/mutation-testing/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "mutation-testing",
-  "version": "1.0.0",
-  "description": "Test suite quality validation through mutation testing - finds weak tests and measures mutation score beyond coverage",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/otel-monitoring-setup/.claude-plugin/plugin.json
+++ b/plugins/otel-monitoring-setup/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "otel-monitoring-setup",
-  "version": "1.0.0",
-  "description": "OpenTelemetry monitoring setup for Claude Code usage tracking, cost analysis, and productivity metrics",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/react-project-scaffolder/.claude-plugin/plugin.json
+++ b/plugins/react-project-scaffolder/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "react-project-scaffolder",
-  "version": "1.0.0",
-  "description": "React project scaffolding with modern tooling - sandbox mode (Vite), enterprise mode (Next.js with testing and CI/CD)",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/semantic-release-tagger/.claude-plugin/plugin.json
+++ b/plugins/semantic-release-tagger/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "semantic-release-tagger",
-  "version": "1.0.0",
-  "description": "Automated git tagging and release management using conventional commits and semantic versioning",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/skill-creator/.claude-plugin/plugin.json
+++ b/plugins/skill-creator/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "skill-creator",
-  "version": "1.0.0",
-  "description": "Claude Code skill generation following Claudex marketplace standards with templates, pattern detection, and quality validation",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/skill-isolation-tester/.claude-plugin/plugin.json
+++ b/plugins/skill-isolation-tester/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "skill-isolation-tester",
-  "version": "1.0.0",
-  "description": "Skill validation in isolation environments (git worktree, Docker, VMs) before public release",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/strict-tool-implementer/.claude-plugin/plugin.json
+++ b/plugins/strict-tool-implementer/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "strict-tool-implementer",
-  "version": "1.0.0",
-  "description": "Anthropic API strict tool use implementation for guaranteed schema compliance and validated inputs",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/structured-outputs-advisor/.claude-plugin/plugin.json
+++ b/plugins/structured-outputs-advisor/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "structured-outputs-advisor",
-  "version": "1.0.0",
-  "description": "Expert advisor for Anthropic structured outputs - choosing between JSON outputs and strict tool use",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/plugins/sub-agent-creator/.claude-plugin/plugin.json
+++ b/plugins/sub-agent-creator/.claude-plugin/plugin.json
@@ -1,9 +1,0 @@
-{
-  "name": "sub-agent-creator",
-  "version": "1.0.0",
-  "description": "Specialized Claude Code sub-agent creation following Anthropic patterns with proper tool configuration",
-  "author": {
-    "name": "Connor",
-    "email": "noreply@claudex.dev"
-  }
-}

--- a/scripts/validate-marketplace.py
+++ b/scripts/validate-marketplace.py
@@ -139,7 +139,8 @@ class MarketplaceValidator:
     def _validate_plugin_entry(self, plugin: Dict, idx: int, plugin_names: Set[str]):
         """Validate a single plugin entry per Anthropic schema."""
         # Check required fields per Anthropic schema
-        required_fields = ['name', 'description', 'source', 'strict', 'skills']
+        # Note: strict and skills/hooks are NOT required - Claude Code auto-discovers components
+        required_fields = ['name', 'description', 'source']
 
         plugin_name = plugin.get('name', f'Plugin #{idx}')
 
@@ -162,18 +163,27 @@ class MarketplaceValidator:
             elif not source.startswith('./'):
                 self.warnings.append(f"Plugin '{plugin_name}': Source should start with './' (Anthropic pattern)")
 
-        # Validate strict field (boolean)
+        # Validate strict field (boolean) - OPTIONAL, defaults to true
         if 'strict' in plugin:
             if not isinstance(plugin['strict'], bool):
                 self.errors.append(f"Plugin '{plugin_name}': 'strict' must be a boolean")
+            # Warn if strict: false is used (causes manifest conflicts)
+            if plugin.get('strict') is False:
+                self.warnings.append(f"Plugin '{plugin_name}': 'strict: false' can cause manifest conflicts with plugin.json")
 
-        # Validate skills array
+        # Validate skills array - OPTIONAL, Claude Code auto-discovers from skills/ directory
         if 'skills' in plugin:
             skills = plugin['skills']
             if not isinstance(skills, list):
                 self.errors.append(f"Plugin '{plugin_name}': 'skills' must be an array")
             elif len(skills) == 0:
                 self.warnings.append(f"Plugin '{plugin_name}': Empty skills array")
+            else:
+                self.warnings.append(f"Plugin '{plugin_name}': Explicit 'skills' field is deprecated - Claude Code auto-discovers from skills/ directory")
+
+        # Validate hooks - OPTIONAL, Claude Code auto-discovers from hooks/ directory
+        if 'hooks' in plugin:
+            self.warnings.append(f"Plugin '{plugin_name}': Explicit 'hooks' field is deprecated - Claude Code auto-discovers from hooks/ directory")
 
     def _validate_source_isolation(self):
         """Validate source path patterns.
@@ -211,13 +221,14 @@ class MarketplaceValidator:
             )
 
     def _validate_skill_references(self):
-        """Validate that skill paths are correctly formatted."""
+        """Validate that skill paths are correctly formatted (for legacy explicit skills arrays)."""
         if 'plugins' not in self.marketplace:
             return
 
         all_skill_paths: Set[str] = set()
 
         for plugin in self.marketplace['plugins']:
+            # Skip plugins without explicit skills array (modern pattern - auto-discovery)
             if 'name' not in plugin or 'skills' not in plugin:
                 continue
 
@@ -241,19 +252,20 @@ class MarketplaceValidator:
                 all_skill_paths.add(skill_path)
 
     def _validate_skill_files(self):
-        """Validate that skill directories and SKILL.md files exist."""
+        """Validate that skill directories and SKILL.md files exist.
+
+        Supports two patterns:
+        1. Legacy explicit skills arrays (validates paths from skills field)
+        2. Modern auto-discovery (validates skills/ directory structure)
+        """
         if 'plugins' not in self.marketplace:
             return
 
         for plugin in self.marketplace['plugins']:
-            if 'name' not in plugin or 'skills' not in plugin:
+            if 'name' not in plugin:
                 continue
 
             plugin_name = plugin['name']
-            skills = plugin['skills']
-
-            if not isinstance(skills, list):
-                continue
 
             # Get plugin source directory for relative path resolution
             plugin_source = plugin.get('source', './')
@@ -262,46 +274,61 @@ class MarketplaceValidator:
             else:
                 plugin_source_dir = self.repo_root / plugin_source
 
-            for skill_path in skills:
-                if not isinstance(skill_path, str):
+            # Check if plugin has explicit skills array (legacy) or uses auto-discovery (modern)
+            if 'skills' in plugin:
+                skills = plugin['skills']
+                if not isinstance(skills, list):
                     continue
 
-                # Resolve skill directory path relative to plugin source
-                if skill_path.startswith('./'):
-                    skill_dir = plugin_source_dir / skill_path.lstrip('./')
+                # Validate explicit skill paths
+                for skill_path in skills:
+                    if not isinstance(skill_path, str):
+                        continue
+                    self._validate_single_skill(plugin_name, plugin_source_dir, skill_path)
+            else:
+                # Modern pattern: auto-discover skills from skills/ directory
+                skills_dir = plugin_source_dir / 'skills'
+                if skills_dir.exists() and skills_dir.is_dir():
+                    for skill_subdir in skills_dir.iterdir():
+                        if skill_subdir.is_dir():
+                            skill_path = f"./skills/{skill_subdir.name}"
+                            self._validate_single_skill(plugin_name, plugin_source_dir, skill_path)
                 else:
-                    skill_dir = plugin_source_dir / skill_path
+                    self.warnings.append(f"Plugin '{plugin_name}': No skills/ directory found for auto-discovery")
 
-                # Check directory exists
-                if not skill_dir.exists():
-                    self.errors.append(f"Plugin '{plugin_name}': Skill directory not found: {skill_path}")
-                    continue
+    def _validate_single_skill(self, plugin_name: str, plugin_source_dir: Path, skill_path: str):
+        """Validate a single skill directory and its SKILL.md file."""
+        # Resolve skill directory path relative to plugin source
+        if skill_path.startswith('./'):
+            skill_dir = plugin_source_dir / skill_path.lstrip('./')
+        else:
+            skill_dir = plugin_source_dir / skill_path
 
-                if not skill_dir.is_dir():
-                    self.errors.append(f"Plugin '{plugin_name}': Skill path is not a directory: {skill_path}")
-                    continue
+        # Check directory exists
+        if not skill_dir.exists():
+            self.errors.append(f"Plugin '{plugin_name}': Skill directory not found: {skill_path}")
+            return
 
-                # Check SKILL.md exists (Anthropic pattern - NO plugin.json)
-                skill_md_path = skill_dir / "SKILL.md"
-                if not skill_md_path.exists():
-                    self.errors.append(f"Plugin '{plugin_name}': Missing SKILL.md at {skill_path}/SKILL.md")
-                    continue
+        if not skill_dir.is_dir():
+            self.errors.append(f"Plugin '{plugin_name}': Skill path is not a directory: {skill_path}")
+            return
 
-                # Validate SKILL.md has content
-                try:
-                    with open(skill_md_path, 'r') as f:
-                        content = f.read()
-                        if len(content.strip()) == 0:
-                            self.errors.append(f"Plugin '{plugin_name}': SKILL.md is empty in {skill_path}")
-                        elif len(content) < 100:
-                            self.warnings.append(f"Plugin '{plugin_name}': SKILL.md seems very short in {skill_path} ({len(content)} chars)")
-                except Exception as e:
-                    self.errors.append(f"Plugin '{plugin_name}': Could not read SKILL.md in {skill_path}: {e}")
+        # Check SKILL.md exists (Anthropic pattern)
+        skill_md_path = skill_dir / "SKILL.md"
+        if not skill_md_path.exists():
+            self.errors.append(f"Plugin '{plugin_name}': Missing SKILL.md at {skill_path}/SKILL.md")
+            return
 
-                # Warn if plugin.json exists (not part of Anthropic pattern)
-                plugin_json_path = skill_dir / "plugin.json"
-                if plugin_json_path.exists():
-                    self.warnings.append(f"Skill '{skill_path}': Contains plugin.json (not required in Anthropic schema, marketplace.json is single source of truth)")
+        # Validate SKILL.md has content
+        try:
+            with open(skill_md_path, 'r') as f:
+                content = f.read()
+                if len(content.strip()) == 0:
+                    self.errors.append(f"Plugin '{plugin_name}': SKILL.md is empty in {skill_path}")
+                elif len(content) < 100:
+                    self.warnings.append(f"Plugin '{plugin_name}': SKILL.md seems very short in {skill_path} ({len(content)} chars)")
+        except Exception as e:
+            self.errors.append(f"Plugin '{plugin_name}': Could not read SKILL.md in {skill_path}: {e}")
 
     def _is_valid_semver(self, version: str) -> bool:
         """Check if version follows semantic versioning format."""
@@ -336,16 +363,28 @@ class MarketplaceValidator:
         if len(self.errors) == 0:
             plugin_count = len(self.marketplace.get('plugins', []))
 
-            # Count total skills
+            # Count total skills (auto-discovered from directory structure)
             total_skills = 0
             for plugin in self.marketplace.get('plugins', []):
                 if 'skills' in plugin and isinstance(plugin['skills'], list):
+                    # Legacy explicit skills array
                     total_skills += len(plugin['skills'])
+                else:
+                    # Modern auto-discovery: count skills/ subdirectories
+                    plugin_source = plugin.get('source', './')
+                    if plugin_source.startswith('./'):
+                        plugin_source_dir = self.repo_root / plugin_source.lstrip('./')
+                    else:
+                        plugin_source_dir = self.repo_root / plugin_source
+
+                    skills_dir = plugin_source_dir / 'skills'
+                    if skills_dir.exists() and skills_dir.is_dir():
+                        total_skills += sum(1 for d in skills_dir.iterdir() if d.is_dir())
 
             print(f"{Colors.GREEN}{Colors.BOLD}✅ Validation passed!{Colors.RESET}")
             print(f"   Marketplace: {self.marketplace.get('name', 'unknown')}")
-            print(f"   Plugin groups: {plugin_count}")
-            print(f"   Total skills: {total_skills}")
+            print(f"   Plugins: {plugin_count}")
+            print(f"   Skills (auto-discovered): {total_skills}")
             print(f"   Warnings: {len(self.warnings)}")
             print()
         else:


### PR DESCRIPTION
## Chapter: Eliminating the Plugin Manifest War

### The Ask
After upgrading to latest Claude Code, `/doctor` reported 24 plugin errors:
- 23 "Plugin has conflicting manifests" errors
- 1 "Hook load failed" error for cc-insights

### The Journey
1. **Root cause analysis**: Claude Code was finding both marketplace.json entries AND individual plugin.json files, causing manifest conflicts
2. **First fix**: Deleted all 23 plugin.json files - metadata now lives exclusively in marketplace.json (single source of truth)
3. **Second fix**: cc-insights hooks.json used wrong schema format. Anthropic's hook schema requires nested matcher-groups with `hooks` arrays, not direct handlers
4. **Verification**: Reinstalled marketplace, ran `/doctor` - 0 errors

### The Architecture

**Before (broken)**:
```
marketplace.json → defines plugin metadata
plugin.json → ALSO defines plugin metadata
Claude Code → "conflicting manifests!"
```

**After (fixed)**:
```
marketplace.json → single source of truth
skills/ directory → auto-discovered by Claude Code
hooks/ directory → auto-discovered by Claude Code
```

**Hook schema fix**:
```json
// WRONG (old format)
{ "hooks": { "Stop": [{ "command": ["bash", "./path"] }] }}

// CORRECT (Anthropic format)
{ "hooks": { "Stop": [{ "hooks": [{ "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/path" }] }] }}
```

### The Outcome
- 23 plugin.json files deleted
- cc-insights hooks.json converted to correct schema
- `/doctor` shows 0 plugin errors
- All 23 plugins load successfully

### The Lessons
- Anthropic's hook schema uses **matcher groups** containing **hooks arrays** - not direct handlers
- Use `${CLAUDE_PLUGIN_ROOT}` for paths in hooks, not relative `./` paths
- Single source of truth for plugin metadata prevents conflicts

### Commit Narrative
- `fix(marketplace)`: Single commit addressing both manifest conflicts and hook schema

### References
- [Anthropic Hook Documentation](https://code.claude.com/docs/en/hooks)
- [Official hookify plugin](https://github.com/anthropics/claude-code/tree/main/plugins/hookify)

---

🤖 Generated with [Claude Code](https://claude.ai/code)